### PR TITLE
Add support for HTML report

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,8 @@
+var fs = require('fs');
+var path = require('path');
+
+var _ = require('lodash');
+var handlebars = require('handlebars');
 var AxeBuilder = require('axe-webdriverjs');
 
 /**
@@ -14,268 +19,50 @@ var AxeBuilder = require('axe-webdriverjs');
  *        standardsToReport: ['wcag2a', 'wcag2aa'],
  *        ignoreAxeFailures: true|false,
  *        package: 'protractor-axe-report-plugin',
+ *        htmlReportPath: '/path/to/reports'|null
  *      }]
  *    }
  *
  */
 
-// Runs axe test against the current page loaded by the webdriver
-// Global method, accessible from tests. 
-runAxeTest = function(testName, driver) {
-  return new Promise((resolve, reject) => {
-    AxeBuilder(driver)
-      .analyze(function (results) {
-        addResults(testName, '', results);
-        resolve(results);
-      });
-  });
-}
-
-// Runs axe test against the selector on the current page loaded by the webdriver, 
-// Global method, accessible from tests. 
-runAxeTestWithSelector = function(testName, driver, selector) {
-  return new Promise((resolve, reject) => {
-    AxeBuilder(driver)
-      .include(selector)
-      .analyze(function (results) {
-        addResults(testName, '', results);
-        resolve(results);
-      });
-  });
-}
-
-var allTestResults = [];
-var currentTestResults = [];
-var resultsByTag = {};
+const allTestResults = [];
+const currentTestResults = [];
+var browserName = '';
 
 const green = '\x1b[32m';
 const red = '\x1b[31m';
 const grey = '\x1b[37m';
 const normalColor = '\x1b[39m';
-const indent = '       ';
+const indent = '  ';
 
-
-function addResults(testName, url, results) {
-  allTestResults.push({name: testName, url: url, axeResults: results});
-  currentTestResults.push({name: testName, url: url, axeResults: results});
+function setup() {
+  browser.runAxeTest = runAxeTest;
 }
 
-function displayViolation(result, displayHelpUrl, displayContext) {
-  var label = result.nodes.length === 1 ? ' element ' : ' elements ';
-
-  console.log(red, 'Fail:', result.help, normalColor);
-  
-  if(displayHelpUrl) {
-    console.log(grey, '     ', result.helpUrl, normalColor);
-  }
-
-  if(displayContext) {
-    var msg = result.nodes.reduce(function(msg, node) {
-      return msg + indent + node.html + '\n\n';
-    }, '\n');
-    msg = '\n' + grey + indent + result.nodes.length + label + 'failed:' + '\n' + msg + normalColor;
-
-    console.log(msg);
-  }
-}
-
-function displayPass(result) {
-  console.log(green,'Pass:', result.help, normalColor);
-}
-
-function getDefault(parameter, defaultValue) {
-  if(parameter == null) {
-    return defaultValue;
-  }
-  else {
-    return parameter;
-  }
-}
-
-function addToResultsByTag(result, resultsByTag, resultType) {
-  if(resultType !== 'pass' && resultType !== 'violation') {
-    throw new Error('resultType must be "pass" or "violation". We got "' + resultType + '"');
-  }
-
-  result.tags.forEach(function(tag) {
-    if(resultsByTag[tag] == null) {
-      resultsByTag[tag] = {};
-    }
-
-    if(resultsByTag[tag][result.id] == null) {
-      resultsByTag[tag][result.id] = {};
-      resultsByTag[tag][result.id]['pass'] = 0;    
-      resultsByTag[tag][result.id]['violation'] = 0;    
-    }
-
-    resultsByTag[tag][result.id][resultType]++;    
-    resultsByTag[tag][result.id].help = result.help;
-    resultsByTag[tag][result.id].description = result.description;
-    resultsByTag[tag][result.id].helpUrl = result.helpUrl;
-  });
-}
-
-function getSummaryString(numPasses, numViolations) {
-  var passLabel = numPasses === 1 ? ' pass ' : ' passes ';
-  var violationLabel = numViolations === 1 ? ' violation' : ' violations';
-
-  return numPasses + passLabel + ' and ' + numViolations + violationLabel;
-}
-
-function isStandardReportable(reportedStandard, standardsToReport) {
-
-  // If we haven't specified any standards, report on them all
-  if(standardsToReport.length === 0) {
-    return true;
-  }
-
-  return standardsToReport.some(function(standardToReport) {
-    return standardToReport === reportedStandard;
-  })
-}
-
-function areAnyStandardsReportable(reportedStandards, standardsToReport) {
-  // If nothing has been specified in standardsToReport, then check if we want to report on the current result
-
-  // If we haven't specified any standards, report on them all
-  if(standardsToReport.length === 0) {
-    return true;
-  }
-
-  return reportedStandards.some(function(reportedStandard) { 
-    return isStandardReportable(reportedStandard, standardsToReport);
-  })
-}
-
-function filterTestResultByStandard(result, standardsToReport)
-{
-  // FIrst, remove issues which are tagged with standards that we don't want to report on
-  result.axeResults.passes = result.axeResults.passes.filter(function(axeResult) {
-    return areAnyStandardsReportable(axeResult.tags, standardsToReport);
-  });
-
-  result.axeResults.violations = result.axeResults.violations.filter(function(axeResult) {
-    return areAnyStandardsReportable(axeResult.tags, standardsToReport);
-  });
-
-  // Next, fromt he remaining issues, remove any references to tags which we don't want to report on
-  result.axeResults.passes.forEach(function(axeResult) {
-    axeResult.tags = axeResult.tags.filter(function(tag) {
-      return isStandardReportable(tag, standardsToReport);
-    })
-  })
-
-  result.axeResults.violations.forEach(function(axeResult) {
-    axeResult.tags = axeResult.tags.filter(function(tag) {
-      return isStandardReportable(tag, standardsToReport);
-    })
-  })
-}
-
-function reportStandardsMessage(standardsToReport) {
-    // If we haven't specified any standards, report on them all
-  if(standardsToReport == null || standardsToReport.length === 0) {
-    console.log("No filters specified - reporting on all standards");
-  }
-  else {
-    console.log("Only returning results for the following standards: " + standardsToReport);
-  }
-}
-
-function displayResultsByStandard(pluginConfig) {
-  // Now log out our overall maps of passes and violations. 
-  console.log("");
-  console.log("--- Accessibilty test results by standard ---");
-  reportStandardsMessage(pluginConfig.standardsToReport);
-
-  // Keep track of whether any check has failed
-  var anyFailure = false;
-
-  allTestResults.forEach(function(testResult) {
-
-    // Build up a map of all passes and failures, grouped by id
-    testResult.axeResults.passes.forEach(function(result) {
-      addToResultsByTag(result, resultsByTag, 'pass');
-    });
-
-    testResult.axeResults.violations.forEach(function(result) {
-      addToResultsByTag(result, resultsByTag, 'violation');
-    });
-  });  
-
-  var tag;
-
-  for (tag in resultsByTag) {
-    if (resultsByTag.hasOwnProperty(tag)) {
-      console.log("");
-      console.log(normalColor,"Standard:", tag);
-
-      var id;
-
-      for (id in resultsByTag[tag]) {
-        if (resultsByTag[tag].hasOwnProperty(id)) {
-          var didThisTestFail = resultsByTag[tag][id].violation > 0;
-          anyFailure = anyFailure | didThisTestFail;
-
-          var resultColor = didThisTestFail ? red : green;
-          var header = didThisTestFail > 0 ? 'Fail: ' : 'Pass: '
-          console.log(' ' + resultColor + header + resultsByTag[tag][id].help + ' (' + resultsByTag[tag][id].pass + ' pass, ' + resultsByTag[tag][id].violation + ' fail)' + normalColor);
-        }
-      }
-    }
-  }
-
-  return anyFailure;
-}
-
-function displayResultsByPage(pluginConfig) {
-  console.log("");
-  console.log("--- Accessibilty test results by page ---");
-  reportStandardsMessage(pluginConfig.standardsToReport);
-
-  allTestResults.forEach(function(testResult) {
-      console.log("");
-      console.log(normalColor,"Test:", testResult.name);
-      console.log(normalColor,"     ", getSummaryString(testResult.axeResults.passes.length, testResult.axeResults.violations.length));
-
-      if(pluginConfig.displayPasses) {
-        testResult.axeResults.passes.forEach(function(result) {
-          displayPass(result);
-        });
-      }
-
-      if(pluginConfig.displayViolations) {
-        testResult.axeResults.violations.forEach(function(result) {
-          displayViolation(result, pluginConfig.displayHelpUrl, pluginConfig.displayContext);
-        });
-      }
-    });
-}
-
-function displayResults() {
+function onPrepare() {
   var pluginConfig = this.config;
 
-  // Remove any results that we are not interested in
-  allTestResults.forEach(function(result) {
-    filterTestResultByStandard(result, pluginConfig.standardsToReport);
-  })
-
-  var anyFailure = displayResultsByStandard(pluginConfig, allTestResults);
-  displayResultsByPage(pluginConfig, allTestResults);
+  pluginConfig.ignoreAxeFailures = getDefault(pluginConfig.ignoreAxeFailures, false);
+  pluginConfig.displayHelpUrl = getDefault(pluginConfig.displayHelpUrl, true);
+  pluginConfig.displayContext = getDefault(pluginConfig.displayContext, true);
+  pluginConfig.displayPasses = getDefault(pluginConfig.displayPasses, true);
+  pluginConfig.displayViolations = getDefault(pluginConfig.displayViolations, true);
+  pluginConfig.standardsToReport = getDefault(pluginConfig.standardsToReport, []);
+  pluginConfig.htmlReportPath = getDefault(pluginConfig.htmlReportPath, null);
 }
 
 function postTest(passed, testInfo) {
-  var pluginConfig = this.config;
-  var context = this;
+  const pluginConfig = this.config;
+  const context = this;
 
-  if(pluginConfig.ignoreAxeFailures) {
+  if (pluginConfig.ignoreAxeFailures) {
     return;
   }
 
   var testHeader = 'aXe - ';
 
   // Process the result to remove any standards that we are not interested in
-  currentTestResults.forEach(function(result) {
+  currentTestResults.forEach((result) => {
     filterTestResultByStandard(result, pluginConfig.standardsToReport);
   });
 
@@ -285,36 +72,284 @@ function postTest(passed, testInfo) {
   var passCount = 0;
   var violationCount = 0;
 
-  currentTestResults.forEach(function(result) {
+  currentTestResults.forEach((result) => {
     passCount += result.axeResults.passes.length;
     violationCount += result.axeResults.violations.length;
   });
 
-  if(violationCount > 0) {
+  if (violationCount > 0) {
     // Ideally we'd just log the errorMessage as specName, but the test doesn't let us match by specName - just by error message
-    var errorMessage = testHeader + testInfo.category + " - " + testInfo.name;
+    var errorMessage = testHeader + testInfo.category + ' - ' + testInfo.name;
     context.addFailure(errorMessage, {specName: errorMessage});
   } else if (passCount > 0) {
-    context.addSuccess({specName: testHeader + testInfo.category + " - " + testInfo.name});
+    context.addSuccess({specName: testHeader + testInfo.category + ' - ' + testInfo.name});
   }
 
   // Clear out the current test results, ready for the next test
   currentTestResults = [];
 }
 
-function onPrepare() {
-  var pluginConfig = this.config;
-
-  // Set the default values for displaying results
-  pluginConfig.ignoreAxeFailures = getDefault(pluginConfig.ignoreAxeFailures, false);
-  pluginConfig.displayHelpUrl = getDefault(pluginConfig.displayHelpUrl, true);
-  pluginConfig.displayContext = getDefault(pluginConfig.displayContext, true);
-  pluginConfig.displayPasses = getDefault(pluginConfig.displayPasses, true);
-  pluginConfig.displayViolations = getDefault(pluginConfig.displayViolations, true);
-  pluginConfig.standardsToReport = getDefault(pluginConfig.standardsToReport, []);
+function postResults() {
+  logAllTestResults.bind(this)();
+  saveReport.bind(this)();
 }
 
-// Export
+function runAxeTest(testName) {
+  return new Promise((resolve, reject) => {
+    browser.driver.getCapabilities()
+      .then((capabilities) => {
+        browserName = capabilities.get('browserName');
+        if (browserName === 'chrome' || browserName === 'firefox') {
+          AxeBuilder(browser.driver)
+            .analyze((results) => {
+              addResults(testName, browserName, results);
+              resolve(results);
+            });
+        } else {
+          console.log(`Skipping aXe tests in unsupported browser (${browserName}).`);
+          resolve();
+        }
+      });
+  });
+}
+
+function runAxeTestWithSelector(testName, selector) {
+  return new Promise((resolve, reject) => {
+    browser.driver.getCapabilities()
+      .then((capabilities) => {
+        browserName = capabilities.get('browserName');
+        if (browserName === 'chrome' || browserName === 'firefox') {
+          AxeBuilder(browser.driver)
+            .include(selector)
+            .analyze(function (results) {
+              addResults(testName, results);
+              resolve(results);
+            });
+        } else {
+          console.log(`Skipping aXe tests in unsupported browser (${browserName}).`);
+          resolve();
+        }
+      });
+  });
+}
+
+function mkdir(dir) {
+  path.dirname(dir)
+    .split(path.sep)
+    .reduce((currentPath, pathSegment) => {
+      currentPath += pathSegment + path.sep;
+      if (!fs.existsSync(currentPath)) {
+        fs.mkdirSync(currentPath);
+      }
+      return currentPath;
+    }, '');
+}
+
+function getDefault(parameter, defaultValue) {
+  return parameter == null ? defaultValue : parameter;
+}
+
+function addResults(testName, browserName, results) {
+  allTestResults.push({ name: testName, browser: browserName, axeResults: results });
+  currentTestResults.push({ name: testName, browser: browserName, axeResults: results });
+}
+
+function filterRuleResultsByStandard(ruleResults, standards) {
+  return ruleResults.reduce(
+    (results, result) => {
+      const isResultForStandard = standards.length > 0
+        ? result.tags.some(Array.prototype.includes.bind(standards))
+        : true;
+
+      if (isResultForStandard) {
+        // remove any references to standards that aren't specified
+        if (standards.length > 0) {
+          result.tags = result.tags.filter(Array.prototype.includes.bind(standards));
+        }
+
+        results.push(result);
+      }
+
+      return results;
+    },
+    []
+  );
+}
+
+function filterTestResultByStandard(testResult, standards) {
+  testResult.axeResults.passes = filterRuleResultsByStandard(testResult.axeResults.passes, standards);
+  testResult.axeResults.violations = filterRuleResultsByStandard(testResult.axeResults.violations, standards);
+  return testResult;
+}
+
+function getSummaryString(passesLength, violationsLength) {
+  var passLabel = passesLength === 1 ? ' pass ' : ' passes ';
+  var violationLabel = violationsLength === 1 ? ' violation' : ' violations';
+
+  return passesLength + passLabel + ' and ' + violationsLength + violationLabel;
+}
+
+function logViolation(result, displayHelpUrl, displayContext) {
+  var label = result.nodes.length === 1 ? ' element ' : ' elements ';
+
+  console.log(red, 'Fail:', result.help, normalColor);
+
+  if (displayHelpUrl) {
+    console.log(grey + indent + result.helpUrl, normalColor);
+  }
+
+  if (displayContext) {
+    var htmlTargets = result.nodes.reduce((msg, node) => msg + indent + node.html + '\n\n', '\n');
+    var msg = grey + indent + result.nodes.length + label + 'failed:' + '\n';
+    msg += htmlTargets + normalColor;
+
+    console.log('');
+    console.log(msg);
+  }
+}
+
+function logPass(result) {
+  console.log(green,'Pass:', result.help, normalColor);
+}
+
+function logStandardsMessage(standards) {
+  if (standards == null || standards.length === 0) {
+    console.log('No filters specified - reporting on all standards');
+  } else {
+    console.log('Only returning results for the following standards:', standards);
+  }
+}
+
+function logAllTestResults() {
+  const testResults = allTestResults.reduce(
+    (results, testResult) => {
+      testResult = filterTestResultByStandard(testResult, this.config.standardsToReport);
+
+      if (testResult.axeResults.passes.length > 0 || testResult.axeResults.violations.length > 0) {
+        results.push(testResult);
+      }
+
+      return results;
+    },
+    []
+  );
+
+  console.log('');
+  console.log('--- Accessibilty test results by test ---');
+
+  logStandardsMessage(this.config.standardsToReport);
+
+  testResults.forEach((testResult) => {
+    console.log('');
+    console.log(normalColor, 'Test:', testResult.name);
+    console.log(
+      normalColor,
+      indent,
+      getSummaryString(testResult.axeResults.passes.length, testResult.axeResults.violations.length)
+    );
+
+    if (this.config.displayPasses) {
+      testResult.axeResults.passes.forEach(logPass);
+    }
+
+    if (this.config.displayViolations) {
+      testResult.axeResults.violations.forEach((result) => {
+        logViolation(result, this.config.displayHelpUrl, this.config.displayContext);
+      });
+    }
+  });
+}
+
+function saveReport() {
+  if (this.config.htmlReportPath === null) {
+    return;
+  }
+
+  const htmlTemplateFilename = path.resolve(__dirname, 'report.hbs');
+  const htmlReportFilename = path.resolve(process.cwd(), this.config.htmlReportPath, `a11y-${browserName}.html`);
+
+  const impactSortWeight = [
+    'minor',
+    'moderate',
+    'serious',
+    'critical'
+  ];
+
+  const ruleResultsSortCompare = function(a, b) {
+    if (a === b) {
+      return 0;
+    }
+
+    const aIndex = impactSortWeight.indexOf(a.impact);
+    const bIndex = impactSortWeight.indexOf(b.impact);
+
+    return aIndex < bIndex ? 1 : -1;
+  };
+
+  const testResults = allTestResults.reduce(
+    (results, testResult) => {
+      testResult = filterTestResultByStandard(testResult, this.config.standardsToReport);
+
+      testResult.axeResults.passes.sort(ruleResultsSortCompare);
+      testResult.axeResults.violations.sort(ruleResultsSortCompare);
+
+      if (testResult.axeResults.passes.length > 0 || testResult.axeResults.violations.length > 0) {
+        results.push(testResult);
+      }
+
+      return results;
+    },
+    []
+  );
+
+  if (testResults.length === 0) {
+    return;
+  }
+
+  let templateContent;
+
+  try {
+    templateContent = fs.readFileSync(htmlTemplateFilename, 'utf-8');
+  } catch (e) {
+    throw new Error(`Something went wrong while trying to load htmlTemplateFilename from ${htmlTemplateFilename} (${e.message})!`);
+  }
+
+  handlebars.registerHelper('link', function(text, url) {
+    text = handlebars.Utils.escapeExpression(text);
+    url = handlebars.Utils.escapeExpression(url);
+
+    var result = `<a href="${url}" target="_blank">${text}</a>`;
+
+    return new handlebars.SafeString(result);
+  });
+
+  handlebars.registerHelper('startCase', function(value) {
+    return _.startCase(value);
+  });
+
+  handlebars.registerHelper('commaDelimitedList', function(value) {
+    return value.join(', ');
+  });
+
+  const template = handlebars.compile(templateContent);
+  const html = template({
+    testResults,
+    browserName,
+    displayViolations: this.config.displayViolations,
+    displayPasses: this.config.displayPasses
+  });
+
+  try {
+    mkdir(htmlReportFilename);
+    fs.writeFileSync(htmlReportFilename, html, 'utf-8');
+  } catch (e) {
+    throw new Error(`Something went wrong while trying to write htmlReportFilename to ${htmlReportFilename} (${e.message})!`);
+  }
+}
+
+exports.setup = setup;
 exports.onPrepare = onPrepare;
-exports.postResults = displayResults;
 exports.postTest = postTest;
+exports.postResults = postResults;
+exports.runAxeTest = runAxeTest;
+exports.runAxeTestWithSelector = runAxeTestWithSelector;

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ const indent = '  ';
 
 function setup() {
   browser.runAxeTest = runAxeTest;
+  browser.runAxeTestWithSelector = runAxeTestWithSelector;
 }
 
 function onPrepare() {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "dependencies": {
     "axe-core": "^2.0.5",
     "axe-webdriverjs": "^0.2.0",
+    "handlebars": "^4.0.11",
+    "lodash": "^4.17.4",
     "selenium-webdriver": "^2.46.1"
   },
   "description": "A protractor plugin that generates an aXe accessibility report",

--- a/report.hbs
+++ b/report.hbs
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Accessibility Report for {{startCase browserName}}</title>
+
+  <style>
+    html,
+    body {
+      margin: 0;
+      padding: 0;
+      background-color: #fff;
+      font-family: Arial, Helvetica, sans-serif;
+      font-size: 16px;
+      line-height: 22px;
+      color: #333;
+    }
+
+    li {
+      margin-bottom: 15px;
+    }
+
+    pre {
+      white-space: pre-wrap;
+      overflow: auto;
+    }
+
+    .page {
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 25px;
+    }
+
+    .counts {
+      margin-top: 30px;
+      font-size: 20px;
+    }
+
+    .count {
+      display: inline-block;
+      padding: 5px;
+      border-radius: 5px;
+      border: 1px solid #eee;
+    }
+
+    .clean-list {
+      margin-left: 0;
+      padding-left: 0;
+      list-style: none;
+    }
+
+    .results-list {
+      margin-top: 30px;
+    }
+
+    .result {
+      padding: 10px;
+      border-radius: 5px;
+      border: 1px solid #eee;
+    }
+
+    .result-description {
+      font-size: 16px;
+      font-weight: bold;
+    }
+
+    .error {
+      color: #721c24;
+      background-color: #f8d7da;
+      border-color: #f5c6cb;
+    }
+
+    .success {
+      color: #155724;
+      background-color: #d4edda;
+      border-color: #c3e6cb;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="page">
+    <h1>Accessibility Report for {{startCase browserName}}</h1>
+
+    {{#each testResults}}
+      <hr />
+      <h2>{{name}}</h2>
+
+      <p class="counts">
+        <span class="count error">{{axeResults.violations.length}} violation(s)</span>
+        <span class="count success">{{axeResults.passes.length}} passes(s)</span>
+      </p>
+
+      <ul class="clean-list results-list">
+        {{#if ../displayViolations}}
+        {{#each axeResults.violations}}
+          <li class="result error">
+            <p class="result-description">{{startCase impact}}: {{description}}</p>
+            <p>{{id}} [{{commaDelimitedList tags}}] (<a href="helpUrl" target="_top">{{helpUrl}}</a>)</p>
+            <ul>
+              {{#each nodes}}
+                <li><code>{{html}}</code> (select with <code>{{target}}</code>)</li>
+              {{/each}}
+            </ul>
+          </li>
+        {{/each}}
+        {{/if}}
+        {{#if ../displayPasses}}
+        {{#each axeResults.passes}}
+        <li class="result success">
+          <p class="result-description">{{description}}</p>
+          <p>{{id}} [{{commaDelimitedList tags}}] ({{link helpUrl helpUrl}})</p>
+        </li>
+        {{/each}}
+        {{/if}}
+      </ul>
+    {{/each}}
+  </div>
+</body>
+</html>


### PR DESCRIPTION
* Add HTML report option
* Remove logging/reporting by standard
* Use global `browser` and `browser.driver` instead of passing into `runAxeTest*`
* Add `runAxeTest` and `runAxeTestWithSelector` to the `browser` instance instead of relying on global
* Export `runAxeTest` and `runAxeTestWithSelector`
* Enforce browser checking to only run aXe tests against Chrome and Firefox